### PR TITLE
feat: Add initial Python library structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,39 @@
 For ibgib python-related code.
 
 I'm not going to get to this until other areas of ibgib are further along, but definitely this or mojo is on the roadmap.
+
+## Project Structure
+
+The project has been initialized with a basic Python library structure:
+
+```
+python_gib/
+├── __init__.py
+├── src/
+│   ├── __init__.py
+│   └── core.py     # Main library code (e.g., foo() function)
+└── tests/
+    ├── __init__.py
+    └── test_core.py # Unit tests for core.py
+setup.py             # Package setup information
+README.md            # This file
+```
+
+- The main library code is located in `python_gib/src/`.
+- Unit tests are in `python_gib/tests/`.
+
+## Running Tests
+
+To run the unit tests, navigate to the root directory of the project (the directory containing `setup.py`) and execute the following command in your terminal:
+
+```bash
+python -m unittest discover -s python_gib/tests
+```
+
+Alternatively, you can run a specific test file directly. For example, to run the tests in `test_core.py`:
+
+```bash
+python python_gib/tests/test_core.py
+```
+
+These commands assume you have Python installed and configured in your system's PATH. The test runner will indicate if all tests pass (`OK`) or provide details of any failures.

--- a/python_gib/__init__.py
+++ b/python_gib/__init__.py
@@ -1,0 +1,1 @@
+# This file makes python_gib a package.

--- a/python_gib/src/__init__.py
+++ b/python_gib/src/__init__.py
@@ -1,0 +1,1 @@
+# This file makes src a package.

--- a/python_gib/src/core.py
+++ b/python_gib/src/core.py
@@ -1,0 +1,3 @@
+def foo():
+  """A simple function that returns 'bar'."""
+  return "bar"

--- a/python_gib/tests/__init__.py
+++ b/python_gib/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes tests a package.

--- a/python_gib/tests/test_core.py
+++ b/python_gib/tests/test_core.py
@@ -1,0 +1,9 @@
+import unittest
+from python_gib.src.core import foo
+
+class TestCore(unittest.TestCase):
+    def test_foo(self):
+        self.assertEqual(foo(), "bar")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='python_gib',
+    version='0.1.0',
+    description='A simple Python project.',
+    author='Your Name',
+    author_email='your.email@example.com',
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [],
+    },
+)


### PR DESCRIPTION
Sets up a basic Python library with an idiomatic project structure.

Includes:
- A `python_gib` package with `src` and `tests` submodules.
- A simple `foo()` function in `python_gib/src/core.py`.
- A unit test for `foo()` in `python_gib/tests/test_core.py` using the `unittest` module.
- A `setup.py` file for package installation and metadata.
- Updated `README.md` with project structure and test execution instructions.

This addresses issue #1 by creating the foundational layout for the Python port of the TypeScript library.