### PR TITLE
feat: Add type hints and update foo function

### DIFF
--- a/python_gib/src/core.py
+++ b/python_gib/src/core.py
@@ -1,3 +1,19 @@
-def foo():
-  """A simple function that returns 'bar'."""
-  return "bar"
+from typing import List, Dict, Any
+
+def foo(name: str, age: int, aliases: List[str]) -> Dict[str, Any]:
+  """
+  Processes and returns user information.
+
+  Args:
+    name: The user's name.
+    age: The user's age.
+    aliases: A list of the user's aliases.
+
+  Returns:
+    A dictionary containing the user's name, age, and aliases.
+  """
+  return {
+      "name": name,
+      "age": age,
+      "aliases": aliases,
+  }

--- a/python_gib/tests/test_core.py
+++ b/python_gib/tests/test_core.py
@@ -3,7 +3,15 @@ from python_gib.src.core import foo
 
 class TestCore(unittest.TestCase):
     def test_foo(self):
-        self.assertEqual(foo(), "bar")
+        name = "Test User"
+        age = 30
+        aliases = ["tester", "example"]
+        expected_output = {
+            "name": name,
+            "age": age,
+            "aliases": aliases,
+        }
+        self.assertEqual(foo(name=name, age=age, aliases=aliases), expected_output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Updates the `foo` function in `python_gib/src/core.py` to include type hints for its arguments (name: str, age: int, aliases: List[str]) and its return value (Dict[str, Any]). The function logic is updated to process these inputs and return them in a dictionary.

The corresponding unit test in `python_gib/tests/test_core.py` has also been updated to reflect these changes, ensuring the function behaves as expected with the new signature and functionality.

This provides a clear example of type hinting usage in Python as requested by you.