### PR TITLE
feat: Port sha256v1 hashing and tests to Python

### DIFF
--- a/python_ibgib/__init__.py
+++ b/python_ibgib/__init__.py
@@ -1,0 +1,9 @@
+# This file makes Python treat the 'python_ibgib' directory as a package.
+# This helps in organizing and importing modules from this directory.
+
+# Optionally, you can make functions from ibgib_helper directly available 
+# when importing python_ibgib, e.g.:
+# from .ibgib_helper import to_normalized_for_hashing, sha256v1
+
+# For now, keeping it simple. Users will import via:
+# from python_ibgib.ibgib_helper import ...

--- a/python_ibgib/ibgib_helper.py
+++ b/python_ibgib/ibgib_helper.py
@@ -1,0 +1,142 @@
+# python_ibgib/ibgib_helper.py
+
+from typing import Any
+import hashlib
+import json
+
+def to_normalized_for_hashing(obj: Any) -> Any:
+    """
+    Normalizes an object for hashing, similar to the ibgib-ts implementation.
+    Sorts dictionary keys alphabetically and removes keys with None values.
+
+    - None input returns None.
+    - Strings are returned as is (being immutable).
+    - Lists are shallow copied (their elements are not deeply normalized by this specific step,
+      matching TypeScript's obj.concat() for arrays).
+    - Other non-dict types (int, float, bool, tuple, set, etc.) are returned as is.
+    - Dictionaries are deeply normalized:
+        - Keys are sorted alphabetically.
+        - Key-value pairs where value is None are excluded.
+        - Values that are dicts or lists are recursively passed to to_normalized_for_hashing.
+    """
+    if obj is None:
+        return None
+
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, list):
+        return obj[:]
+
+    if not isinstance(obj, dict):
+        return obj
+
+    normalized_dict = {}
+    sorted_keys = sorted(obj.keys())
+
+    for key in sorted_keys:
+        value = obj[key]
+        if value is not None:
+            if isinstance(value, dict) or isinstance(value, list):
+                normalized_dict[key] = to_normalized_for_hashing(value)
+            else:
+                normalized_dict[key] = value
+                
+    return normalized_dict
+
+# Helper function for sha256v1
+def _hash_to_hex(message: Any) -> str:
+    """
+    Computes SHA256 hash and returns uppercase hex digest.
+    Returns "" for None, empty string, or empty bytes.
+    Input `message` can be str or bytes.
+    """
+    if not message:  # Handles None, empty string, empty bytes
+        return ""
+    
+    data_to_hash: bytes
+    if isinstance(message, bytes):
+        data_to_hash = message
+    elif isinstance(message, str):
+        data_to_hash = message.encode('utf-8')
+    else:
+        # This case should ideally not be reached if inputs are validated upstream
+        # or are of expected types (str/bytes after JSON stringification).
+        return "" 
+
+    # Ensure that after encoding or if it was initially bytes, it's not empty.
+    # e.g. if an empty string was passed and encoded.
+    # However, `if not message:` at the start handles empty strings already.
+    # If `message` was non-empty string but encoded to empty bytes (e.g. weird unicode),
+    # this check might be relevant, but typically `encode()` on non-empty string
+    # produces non-empty bytes.
+    # For safety, checking `data_to_hash` might be redundant due to initial check.
+    # The first `if not message:` covers empty strings and empty bytes.
+    # Let's assume valid non-empty string/bytes make it here.
+
+    hasher = hashlib.sha256()
+    hasher.update(data_to_hash)
+    return hasher.hexdigest().upper()
+
+def sha256v1(ib_gib: dict) -> str:
+    """
+    Replicates the no-salt version of the TypeScript sha256v1 function.
+    Computes a deterministic SHA256 hash for an ib_gib dictionary structure.
+    """
+    ib = ib_gib.get('ib')
+    data = ib_gib.get('data')
+    rel8ns = ib_gib.get('rel8ns')
+
+    # Determine has_rel8ns
+    # True if rel8ns is a non-empty dict and at least one of its values is a non-empty list.
+    has_rel8ns = False
+    if rel8ns and isinstance(rel8ns, dict): # Ensure rel8ns is not None and is a dict
+        for value in rel8ns.values():
+            if isinstance(value, list) and len(value) > 0:
+                has_rel8ns = True
+                break
+    
+    # Determine has_data
+    # True if data is present and not an empty string or empty dict. Bytes are always data.
+    has_data = False
+    if data is not None:
+        if isinstance(data, str):
+            has_data = len(data) > 0
+        elif isinstance(data, bytes):
+            # In TS, `data instanceof Uint8Array` sets `hasData = true` regardless of length.
+            has_data = True 
+        elif isinstance(data, dict):
+            has_data = bool(data) # True if dict is not empty
+        else:
+            # Other types (numbers, booleans, etc.) are considered data if not None.
+            has_data = True 
+
+    ib_hash = _hash_to_hex(ib)
+
+    rel8ns_hash = ""
+    if has_rel8ns:
+        normalized_rel8ns = to_normalized_for_hashing(rel8ns)
+        # Compact JSON string with sorted keys
+        json_rel8ns = json.dumps(normalized_rel8ns, sort_keys=True, separators=(',', ':'))
+        rel8ns_hash = _hash_to_hex(json_rel8ns)
+
+    data_hash = ""
+    if has_data:
+        if isinstance(data, bytes):
+            data_hash = _hash_to_hex(data) # Hash bytes directly
+        else:
+            normalized_data = to_normalized_for_hashing(data)
+            json_data = json.dumps(normalized_data, sort_keys=True, separators=(',', ':'))
+            data_hash = _hash_to_hex(json_data)
+
+    # Calculate final combined hash
+    # If there's data or rel8ns, concatenate hashes and hash again.
+    # Otherwise, hash the ib_hash again.
+    if has_data or has_rel8ns:
+        combined_content = ib_hash + rel8ns_hash + data_hash
+        all_hash = _hash_to_hex(combined_content)
+    else:
+        # TS: (await hashToHex(ibHash)).toUpperCase()
+        # This means if only 'ib' contributes, its hash is hashed again.
+        all_hash = _hash_to_hex(ib_hash)
+        
+    return all_hash

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the 'tests' directory as a package.

--- a/tests/test_sha256v1.py
+++ b/tests/test_sha256v1.py
@@ -1,0 +1,140 @@
+import unittest
+import json
+import hashlib
+import sys
+import os
+
+# Adjust the Python path to include the root directory for absolute imports
+# This allows 'from python_ibgib.ibgib_helper import ...' to work
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from python_ibgib.ibgib_helper import sha256v1, to_normalized_for_hashing
+
+# Helper function for tests (Python equivalent of hashToHexCopy)
+def hash_to_hex_copy(message: str | bytes) -> str:
+    if not message:
+        return ""
+    if isinstance(message, str):
+        message_bytes = message.encode('utf-8')
+    else:
+        message_bytes = message
+    
+    # Ensure message_bytes is not empty after potential encoding of an empty string
+    # (though initial `if not message:` should catch empty strings)
+    if not message_bytes: # Handles cases like empty string that becomes empty bytes
+        return ""
+        
+    h = hashlib.sha256()
+    h.update(message_bytes)
+    return h.hexdigest().upper()
+
+class TestSha256V1(unittest.TestCase):
+    # Test Data
+    TEST_IBS = {"ib": "ib", "some_test_string_here": "Some test string here."}
+    TEST_HASHES_SHA256_STRINGS = {
+        "ib": "765DBB8C38A58A5DC019D7B3133DFFB251D643CB291328AD8E86D4F05655E68B",
+        "Some test string here.": "E9D61315933F1E8ABCEAA51B2CDD711FBF63C82CBF8C359603907E6DED73DB30"
+    }
+    EMPTY_REL8NS = {}
+    EMPTY_DATA = {}
+    ROOT_IBGIB_ADDR = "ib^gib"
+    DATA_FLAT_XY = {"x": 1, "y": 2}
+    DATA_FLAT_XY_HASH = "689A8F1DB95402580476E38C264278CE7B1E664320CFB4E9AE8D3A908CF09964" # Matches TS `DATA_FLAT_XY_HASH_SHA256`
+    DATA_FLAT_XS = {"x": 1, "s": "string here"}
+    DATA_FLAT_XS_HASH = "EEE1367DC05EDA2D46B8BB7978856261256FC1F59A95E453D9EECA22D235EE54" # Matches TS `DATA_FLAT_XS_HASH_SHA256`
+    REL8NS_SIMPLE = {
+        "past": [ROOT_IBGIB_ADDR],
+        "ancestor": [ROOT_IBGIB_ADDR],
+        "dna": [ROOT_IBGIB_ADDR],
+        "identity": [ROOT_IBGIB_ADDR]
+    }
+    REL8NS_SIMPLE_HASH = "FA54EECD9FB1B5C9D5FD63E5E59C8C6576D14610DB62129F863B3120F4A1A433" # Matches TS `REL8NS_SIMPLE_HASH_SHA256`
+
+    TEST_IBGIBS_PYTHON = [
+        {
+            "ibgib": {
+                "ib": TEST_IBS["ib"],
+                "gib": "34F03B3EC694FBEE1F93944CF6BAD4B6A07FD450276B9FC1A523EB4C1E4157B7",
+                "rel8ns": REL8NS_SIMPLE,
+                "data": DATA_FLAT_XY,
+            },
+            "dataHash": DATA_FLAT_XY_HASH,
+            "rel8nsHash": REL8NS_SIMPLE_HASH,
+        },
+        {
+            "ibgib": {
+                "ib": TEST_IBS["ib"],
+                "gib": "577E5732B8E00539B5FBF27607E09496805BB113232C970958D8DF05BE6164B6",
+                "rel8ns": REL8NS_SIMPLE,
+                "data": DATA_FLAT_XS,
+            },
+            "dataHash": DATA_FLAT_XS_HASH,
+            "rel8nsHash": REL8NS_SIMPLE_HASH,
+        },
+    ]
+
+    def test_hash_internal_strings(self):
+        """Corresponds to `test internal hash function ib: ${x}`."""
+        for text, expected_hash in self.TEST_HASHES_SHA256_STRINGS.items():
+            with self.subTest(text=text):
+                self.assertEqual(hash_to_hex_copy(text), expected_hash)
+
+    def test_hash_ibgibs_with_empty_falsy_data_rel8ns(self):
+        """Corresponds to `should hash ibgibs with empty/null/undefined data/rel8ns consistently "forever"`."""
+        ib = "ib"
+        # This hash is derived from the TS test case:
+        # ibHash = await hashToHex(ib); // 765DBB8C38A58A5DC019D7B3133DFFB251D643CB291328AD8E86D4F05655E68B
+        # manualAllHash = await hashToHex(ibHash); // Since data/rel8ns are empty/falsy
+        # manualAllHash = E975776B1A3E4468086E1D8C409116F6E098D13BEEDFE17AF668071B5D11CD55
+        expected_hash = "E975776B1A3E4468086E1D8C409116F6E098D13BEEDFE17AF668071B5D11CD55"
+        
+        equivalents = [
+            {"ib": ib, "rel8ns": self.EMPTY_REL8NS},
+            {"ib": ib, "rel8ns": self.EMPTY_REL8NS, "data": self.EMPTY_DATA},
+            {"ib": ib, "rel8ns": self.EMPTY_REL8NS, "data": None},
+            {"ib": ib, "rel8ns": self.EMPTY_REL8NS}, # data key missing
+
+            {"ib": ib, "rel8ns": None, "data": self.EMPTY_DATA},
+            {"ib": ib, "rel8ns": None, "data": None},
+            {"ib": ib, "rel8ns": None}, # data key missing
+
+            {"ib": ib, "data": self.EMPTY_DATA}, # rel8ns key missing
+            {"ib": ib, "data": None}, # rel8ns key missing
+            {"ib": ib}, # data and rel8ns keys missing
+        ]
+
+        for i, ibgib_case in enumerate(equivalents):
+            with self.subTest(case_index=i, ibgib=ibgib_case):
+                self.assertEqual(sha256v1(ibgib_case), expected_hash)
+
+    def test_hash_ibgibs_with_simple_data_rel8ns(self):
+        """Corresponds to `should hash ibgibs with non-null data/rel8ns consistently "forever"`."""
+        for i, test_case in enumerate(self.TEST_IBGIBS_PYTHON):
+            with self.subTest(case_index=i, test_case_name=test_case["ibgib"].get("gib", f"case_{i}")):
+                ib = test_case["ibgib"]["ib"]
+                data = test_case["ibgib"]["data"]
+                rel8ns = test_case["ibgib"]["rel8ns"]
+                expected_gib = test_case["ibgib"]["gib"]
+                expected_data_hash = test_case["dataHash"]
+                expected_rel8ns_hash = test_case["rel8nsHash"]
+
+                # Verify intermediate hashes
+                normalized_data = to_normalized_for_hashing(data)
+                current_data_hash = hash_to_hex_copy(json.dumps(normalized_data, sort_keys=True, separators=(',', ':')))
+                self.assertEqual(current_data_hash, expected_data_hash, "Data hash mismatch")
+
+                normalized_rel8ns = to_normalized_for_hashing(rel8ns)
+                current_rel8ns_hash = hash_to_hex_copy(json.dumps(normalized_rel8ns, sort_keys=True, separators=(',', ':')))
+                self.assertEqual(current_rel8ns_hash, expected_rel8ns_hash, "Rel8ns hash mismatch")
+
+                ib_hash = hash_to_hex_copy(ib)
+                # This is how the final hash is constructed if data or rel8ns are present
+                manual_all_hash = hash_to_hex_copy(ib_hash + current_rel8ns_hash + current_data_hash)
+                self.assertEqual(manual_all_hash, expected_gib, "Manual combined hash mismatch")
+
+                # Verify sha256v1 function output
+                calculated_gib_hash = sha256v1(test_case["ibgib"])
+                self.assertEqual(calculated_gib_hash, expected_gib, "sha256v1 function output mismatch")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've ported the core string hashing, ibgib normalization (`toNormalizedForHashing`), and `sha256v1` content-addressing logic from the TypeScript `@ibgib/ts-gib` and `@ibgib/helper-gib` packages to Python.

The key components I ported are:
- `to_normalized_for_hashing`: This sorts dictionary keys alphabetically and removes `None` values recursively to ensure consistent input for hashing.
- `sha256v1`: This computes a SHA256 hash for an "ibgib" structure. It individually hashes the 'ib' string, the normalized 'data' object (JSON stringified), and the normalized 'rel8ns' object (JSON stringified). These component hashes are then concatenated and hashed again to produce the final "gib" hash. All hashes are uppercase hexadecimal strings.

I've also ported unit tests from `sha256v1.respec.mts` to `tests/test_sha256v1.py` using the `unittest` framework. These tests verify:
- Basic string hashing.
- Hashing of ibgibs with empty, null, or undefined data/rel8ns.
- Hashing of ibgibs with structured data and rel8ns, including checks for intermediate dataHash and rel8nsHash values.

All ported tests pass, ensuring the Python implementation aligns with the original TypeScript hashing behavior.