### PR TITLE
This commit introduces 10 new edge case test scenarios (resulting in …

### DIFF
--- a/tests/py_gib/V1/test_sha256v1.py
+++ b/tests/py_gib/V1/test_sha256v1.py
@@ -6,9 +6,9 @@ import os
 
 # Adjust the Python path to include the root directory for absolute imports
 # This allows 'from python_ibgib.ibgib_helper import ...' to work
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))) # Adjusted path
 
-from src.py_gib.V1.sha256v1 import sha256v1, to_normalized_for_hashing
+from src.py_gib.V1.sha256v1 import sha256v1, to_normalized_for_hashing, _hash_to_hex
 
 # Helper function for tests (Python equivalent of hashToHexCopy)
 def hash_to_hex_copy(message: str | bytes) -> str:
@@ -135,6 +135,341 @@ class TestSha256V1(unittest.TestCase):
                 # Verify sha256v1 function output
                 calculated_gib_hash = sha256v1(test_case["ibgib"])
                 self.assertEqual(calculated_gib_hash, expected_gib, "sha256v1 function output mismatch")
+
+    def test_hash_ibgibs_edge_cases(self):
+        # Scenario 1: `data` with mixed `None` and empty string values.
+        with self.subTest(scenario="1_data_mixed_none_empty_string"):
+            ibgib_s1 = {'ib': 's1', 'data': {'a': None, 'b': '', 'c': 'val', 'd': {'d1': None, 'd2': 'd2val'}}}
+            ib_s1 = ibgib_s1['ib']
+            data_s1 = ibgib_s1['data']
+
+            expected_normalized_data_s1 = {'b': '', 'c': 'val', 'd': {'d2': 'd2val'}}
+            actual_normalized_data_s1 = to_normalized_for_hashing(data_s1)
+            self.assertEqual(actual_normalized_data_s1, expected_normalized_data_s1)
+
+            expected_data_hash_s1 = hash_to_hex_copy(json.dumps(expected_normalized_data_s1, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s1, "3310C5015C3426C4EC62CF5F5F3EC5D83F86C26E54C5AC3BD05C1B574B46ADE2")
+            
+            # Intermediate check of data hash within sha256v1 logic (conceptually)
+            # sha256v1 uses _hash_to_hex, but hash_to_hex_copy is similar for this check
+            self.assertEqual(
+                _hash_to_hex(json.dumps(actual_normalized_data_s1, sort_keys=True, separators=(',', ':'))),
+                expected_data_hash_s1  # This now refers to the updated hash
+            )
+
+            ib_hash_s1 = hash_to_hex_copy(ib_s1)
+            # Updated from test log
+            self.assertEqual(ib_hash_s1, "E8BC163C82EEE18733288C7D4AC636DB3A6DEB013EF2D37B68322BE20EDC45CC")
+
+            # sha256v1 specific logic for has_data, has_rel8ns
+            # For s1: has_data is True, has_rel8ns is False. rel8ns_hash is ""
+            expected_gib_s1 = hash_to_hex_copy(ib_hash_s1 + "" + expected_data_hash_s1)
+            # Updated based on new ib_hash_s1 and expected_data_hash_s1, value from FAIL log:
+            self.assertEqual(expected_gib_s1, "9B9D08F270C5249FD1DC2E0453010EBD544C7781FF5CDAFADD7679C2C7DA7247")
+            
+            self.assertEqual(sha256v1(ibgib_s1), expected_gib_s1)
+
+        # Scenario 2: `rel8ns` with a relation mapping to a list containing `None`.
+        with self.subTest(scenario="2_rel8ns_list_with_none"):
+            ibgib_s2 = {'ib': 's2', 'rel8ns': {'next': ['addr1', None, 'addr2'], 'prev': None}}
+            ib_s2 = ibgib_s2['ib']
+            rel8ns_s2 = ibgib_s2['rel8ns']
+
+            expected_normalized_rel8ns_s2 = {'next': ['addr1', None, 'addr2']}
+            actual_normalized_rel8ns_s2 = to_normalized_for_hashing(rel8ns_s2)
+            self.assertEqual(actual_normalized_rel8ns_s2, expected_normalized_rel8ns_s2)
+
+            expected_rel8ns_hash_s2 = hash_to_hex_copy(json.dumps(expected_normalized_rel8ns_s2, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_rel8ns_hash_s2, "32945B4CE582D29827CA925DCA3155CA397C132F0DB1DB5DFF9AD46A8EFD98FE")
+
+            ib_hash_s2 = hash_to_hex_copy(ib_s2)
+            # Updated from test log
+            self.assertEqual(ib_hash_s2, "AD328846AA18B32A335816374511CAC1063C704B8C57999E51DA9F908290A7A4")
+            
+            # For s2: has_data is False (data_hash is ""), has_rel8ns is True.
+            expected_gib_s2 = hash_to_hex_copy(ib_hash_s2 + expected_rel8ns_hash_s2 + "")
+            # Updated based on new ib_hash_s2 and expected_rel8ns_hash_s2, value from FAIL log:
+            self.assertEqual(expected_gib_s2, "8DD27B4AFBE3AD7D59768CB4D1A574DC2FEA19546E922101FED6F6ECA9B97C61")
+
+            self.assertEqual(sha256v1(ibgib_s2), expected_gib_s2)
+
+        # Scenario 3: `data` is an empty list `[]`.
+        with self.subTest(scenario="3_data_empty_list"):
+            ibgib_s3 = {'ib': 's3', 'data': []}
+            ib_s3 = ibgib_s3['ib']
+            data_s3 = ibgib_s3['data']
+
+            # to_normalized_for_hashing for a list returns a shallow copy
+            expected_normalized_data_s3 = [] 
+            actual_normalized_data_s3 = to_normalized_for_hashing(data_s3)
+            self.assertEqual(actual_normalized_data_s3, expected_normalized_data_s3)
+            
+            # sha256v1.py: has_data is True for `data = []` (falls into `else: has_data = True`)
+            # json.dumps([]) -> "[]"
+            expected_data_hash_s3 = hash_to_hex_copy(json.dumps(actual_normalized_data_s3, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s3, "4F53CDA18C2BAA0C0354BB5F9A3ECBE5ED12AB4D8E11BA873C2F11161202B945")
+
+            ib_hash_s3 = hash_to_hex_copy(ib_s3)
+            # Updated from test log
+            self.assertEqual(ib_hash_s3, "41242B9FAE56FAD4E6E77DFE33CB18D1C3FC583F988CF25EF9F2D9BE0D440BBB")
+
+            # For s3: has_data is True, has_rel8ns is False (rel8ns_hash is "").
+            expected_gib_s3 = hash_to_hex_copy(ib_hash_s3 + "" + expected_data_hash_s3)
+            # Updated based on new ib_hash_s3 and expected_data_hash_s3, value from FAIL log:
+            self.assertEqual(expected_gib_s3, "BA109F5B0C09CF0A27EF976F876EE8F336DC954EF6443F324F19D78020E3E59A")
+            
+            self.assertEqual(sha256v1(ibgib_s3), expected_gib_s3)
+
+        # Scenario 4: `data` contains a list with dictionaries, where inner dicts have `None` values.
+        with self.subTest(scenario="4_data_list_with_dicts_with_none"):
+            ibgib_s4 = {'ib': 's4', 'data': {'items': [{'id': 1, 'val': None, 'name': 'item1'}, {'id': 2, 'val': 'present'}]}}
+            ib_s4 = ibgib_s4['ib']
+            data_s4 = ibgib_s4['data']
+
+            # to_normalized_for_hashing for the top-level dict will sort keys ('items').
+            # The list itself is shallow copied. Dictionaries within the list are NOT normalized by to_normalized_for_hashing's list handling.
+            # However, json.dumps WILL sort keys of nested dicts if sort_keys=True.
+            expected_normalized_data_s4 = {'items': [{'id': 1, 'val': None, 'name': 'item1'}, {'id': 2, 'val': 'present'}]}
+            actual_normalized_data_s4 = to_normalized_for_hashing(data_s4)
+            self.assertEqual(actual_normalized_data_s4, expected_normalized_data_s4)
+            
+            # json.dumps output for the above (note key order in inner dicts due to sort_keys=True):
+            # '{"items":[{"id":1,"name":"item1","val":null},{"id":2,"val":"present"}]}'
+            expected_data_hash_s4 = hash_to_hex_copy(json.dumps(actual_normalized_data_s4, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s4, "2682A15F60291F933B57EE14F0A3D5FD233FC90B3FF1ADD5FD473F859FA6B287")
+
+            ib_hash_s4 = hash_to_hex_copy(ib_s4)
+            # Updated from test log
+            self.assertEqual(ib_hash_s4, "5B840157E7E86AEF3B3FD0FC24F3ADD34D3E7F210370D429475ED1BCD3E7FCA2")
+
+            # For s4: has_data is True, has_rel8ns is False (rel8ns_hash is "").
+            expected_gib_s4 = hash_to_hex_copy(ib_hash_s4 + "" + expected_data_hash_s4)
+            # Updated based on new ib_hash_s4 and expected_data_hash_s4, value from FAIL log:
+            self.assertEqual(expected_gib_s4, "2AE26C6F9A4D53CE32A0A1792E59F34126A25503CE33728EA7CB8A38E29DD0BF")
+            
+            self.assertEqual(sha256v1(ibgib_s4), expected_gib_s4)
+
+        # Scenario 5: `data` key order vs. `rel8ns` key order.
+        with self.subTest(scenario="5_data_rel8ns_key_order"):
+            ibgib_s5 = {'ib': 's5', 'data': {'z': 1, 'a': 2}, 'rel8ns': {'z_rel': ['z1'], 'a_rel': ['a1']}}
+            ib_s5 = ibgib_s5['ib']
+            data_s5 = ibgib_s5['data']
+            rel8ns_s5 = ibgib_s5['rel8ns']
+
+            expected_normalized_data_s5 = {'a': 2, 'z': 1} # Keys sorted
+            actual_normalized_data_s5 = to_normalized_for_hashing(data_s5)
+            self.assertEqual(actual_normalized_data_s5, expected_normalized_data_s5)
+            expected_data_hash_s5 = hash_to_hex_copy(json.dumps(actual_normalized_data_s5, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s5, "C2985C5BA6F7D2A55E768F92490CA09388E95BC4CCCB9FDF11B15F4D42F93E73")
+
+            expected_normalized_rel8ns_s5 = {'a_rel': ['a1'], 'z_rel': ['z1']} # Keys sorted
+            actual_normalized_rel8ns_s5 = to_normalized_for_hashing(rel8ns_s5)
+            self.assertEqual(actual_normalized_rel8ns_s5, expected_normalized_rel8ns_s5)
+            expected_rel8ns_hash_s5 = hash_to_hex_copy(json.dumps(actual_normalized_rel8ns_s5, sort_keys=True, separators=(',', ':')))
+            # Updated from S5 specific test log from previous run
+            self.assertEqual(expected_rel8ns_hash_s5, "3C0705B51593C740738A0BFB4D9030C8A8093D8A6049346E823CD033BAAA09E5")
+
+
+            ib_hash_s5 = hash_to_hex_copy(ib_s5)
+            # Updated from S5 specific FAIL log for ib_hash
+            self.assertEqual(ib_hash_s5, "3B96FC064FA874A80A132BDA60BEBF54EFBC780A358FDCAE4FBBD7E12B66B630")
+
+            # For s5: has_data is True, has_rel8ns is True.
+            expected_gib_s5 = hash_to_hex_copy(ib_hash_s5 + expected_rel8ns_hash_s5 + expected_data_hash_s5)
+            # Updated based on the latest FAIL log for expected_gib_s5
+            self.assertEqual(expected_gib_s5, "7AC6FB16BC853C6AE7D375ECEEA810ABB6F60241A1679ADEE4DC6ED4E29BE74A")
+            
+            self.assertEqual(sha256v1(ibgib_s5), expected_gib_s5)
+
+        # Scenario 6: `data` with special characters in string values and keys.
+        with self.subTest(scenario="6_data_special_chars"):
+            ibgib_s6 = {'ib': 's6', 'data': {'key "1"': 'value with "quotes" and \n newline', 'key_ñ': 'val_ü'}}
+            ib_s6 = ibgib_s6['ib']
+            data_s6 = ibgib_s6['data']
+
+            # Note: json.dumps will escape characters like \n to \\n and quotes.
+            # to_normalized_for_hashing sorts keys.
+            expected_normalized_data_s6 = {'key "1"': 'value with "quotes" and \n newline', 'key_ñ': 'val_ü'}
+            actual_normalized_data_s6 = to_normalized_for_hashing(data_s6)
+            self.assertEqual(actual_normalized_data_s6, expected_normalized_data_s6)
+            
+            # json_string: {"key \"1\"":"value with \"quotes\" and \\n newline","key_ñ":"val_ü"}
+            expected_data_hash_s6 = hash_to_hex_copy(json.dumps(actual_normalized_data_s6, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s6, "441200D475E6171CD94518A7AD358C29281DBD962163EE7F1B309058098CECE7")
+
+            ib_hash_s6 = hash_to_hex_copy(ib_s6)
+            # Updated from test log
+            self.assertEqual(ib_hash_s6, "71E7690959239CA065841EBA3EBB281072BAA78BA0BB31079B9ACB4A009A9FE3")
+
+            # For s6: has_data is True, has_rel8ns is False (rel8ns_hash is "").
+            expected_gib_s6 = hash_to_hex_copy(ib_hash_s6 + "" + expected_data_hash_s6)
+            # Updated based on new ib_hash_s6 and expected_data_hash_s6, value from FAIL log:
+            self.assertEqual(expected_gib_s6, "9AF9BE9284CFCE565CBFD482EA0797E0D67CCD0AEDF6509BCEA3B9D4D00931BF")
+            
+            self.assertEqual(sha256v1(ibgib_s6), expected_gib_s6)
+
+        # Scenario 7a: `data` is a primitive type (boolean True).
+        with self.subTest(scenario="7a_data_boolean_true"):
+            ibgib_s7a = {'ib': 's7a', 'data': True}
+            ib_s7a = ibgib_s7a['ib']
+            data_s7a = ibgib_s7a['data']
+
+            expected_normalized_data_s7a = True
+            actual_normalized_data_s7a = to_normalized_for_hashing(data_s7a)
+            self.assertEqual(actual_normalized_data_s7a, expected_normalized_data_s7a)
+            
+            # json.dumps(True) -> "true"
+            expected_data_hash_s7a = hash_to_hex_copy(json.dumps(actual_normalized_data_s7a, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s7a, "B5BEA41B6C623F7C09F1BF24DCAE58EBAB3C0CDD90AD966BC43A45B44867E12B")
+
+            ib_hash_s7a = hash_to_hex_copy(ib_s7a)
+            # Updated from test log
+            self.assertEqual(ib_hash_s7a, "612A9EB864ED62C258BDCB155F13F590879BA34AD30DDE91CB9BE38139439E9F")
+
+            # For s7a: has_data is True, has_rel8ns is False (rel8ns_hash is "").
+            expected_gib_s7a = hash_to_hex_copy(ib_hash_s7a + "" + expected_data_hash_s7a)
+            # Updated based on new ib_hash_s7a and expected_data_hash_s7a, value from FAIL log:
+            self.assertEqual(expected_gib_s7a, "53BBABB9F24C75E3C6037D744C241AF710B6E886C22398537AA9332D5626D022")
+            
+            self.assertEqual(sha256v1(ibgib_s7a), expected_gib_s7a)
+
+        # Scenario 7b: `data` is a primitive type (number).
+        with self.subTest(scenario="7b_data_number"):
+            ibgib_s7b = {'ib': 's7b', 'data': 123.45}
+            ib_s7b = ibgib_s7b['ib']
+            data_s7b = ibgib_s7b['data']
+
+            expected_normalized_data_s7b = 123.45
+            actual_normalized_data_s7b = to_normalized_for_hashing(data_s7b)
+            self.assertEqual(actual_normalized_data_s7b, expected_normalized_data_s7b)
+            
+            # json.dumps(123.45) -> "123.45"
+            expected_data_hash_s7b = hash_to_hex_copy(json.dumps(actual_normalized_data_s7b, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s7b, "4EBC4A141B378980461430980948A55988FBF56F85D084AC33D8A8F61B9FAB88")
+
+            ib_hash_s7b = hash_to_hex_copy(ib_s7b)
+            # Updated from test log
+            self.assertEqual(ib_hash_s7b, "70348C184BB7E09344EEEE0BA0A766D1DB6C1B1E02520A6534C94F78591EBA46")
+
+            # For s7b: has_data is True, has_rel8ns is False (rel8ns_hash is "").
+            expected_gib_s7b = hash_to_hex_copy(ib_hash_s7b + "" + expected_data_hash_s7b)
+            # Updated based on new ib_hash_s7b and expected_data_hash_s7b, value from FAIL log:
+            self.assertEqual(expected_gib_s7b, "F81D2861750A638FBE6F792D66A8EE2408C5F5CB965755166957C46B1B242F41")
+            
+            self.assertEqual(sha256v1(ibgib_s7b), expected_gib_s7b)
+
+        # Scenario 8: `rel8ns` with some relations being empty lists, others non-empty.
+        with self.subTest(scenario="8_rel8ns_empty_and_non_empty_lists"):
+            ibgib_s8 = {'ib': 's8', 'rel8ns': {'past': [], 'future': ['addr1'], 'empty_too': []}}
+            ib_s8 = ibgib_s8['ib']
+            rel8ns_s8 = ibgib_s8['rel8ns']
+
+            # to_normalized_for_hashing sorts keys. Empty lists are preserved.
+            expected_normalized_rel8ns_s8 = {'empty_too': [], 'future': ['addr1'], 'past': []}
+            actual_normalized_rel8ns_s8 = to_normalized_for_hashing(rel8ns_s8)
+            self.assertEqual(actual_normalized_rel8ns_s8, expected_normalized_rel8ns_s8)
+            
+            # json_string: {"empty_too":[],"future":["addr1"],"past":[]}
+            expected_rel8ns_hash_s8 = hash_to_hex_copy(json.dumps(actual_normalized_rel8ns_s8, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_rel8ns_hash_s8, "A98E517BB1289561B164706289F2CCE1423EA9ABCA11FC35BFFD4E0817224760")
+
+            ib_hash_s8 = hash_to_hex_copy(ib_s8)
+            # Updated from test log
+            self.assertEqual(ib_hash_s8, "1CB7637B6957AC5D6F6CDEC745554AFD3CD1537BB6E7A8E74D41C2EA58B89E97")
+
+            # For s8: has_data is False (data_hash is ""), has_rel8ns is True (due to 'future' list).
+            expected_gib_s8 = hash_to_hex_copy(ib_hash_s8 + expected_rel8ns_hash_s8 + "")
+            # Updated based on new ib_hash_s8 and expected_rel8ns_hash_s8, value from FAIL log:
+            self.assertEqual(expected_gib_s8, "EE653CEE56759A6C868A485582E4E66C8B57DFBE1C55CF36BDBF237BF5C09CF8")
+            
+            self.assertEqual(sha256v1(ibgib_s8), expected_gib_s8)
+
+        # Scenario 9: Deeply nested `data` with mixed `None`, lists, and dicts.
+        with self.subTest(scenario="9_data_deeply_nested"):
+            ibgib_s9 = {'ib': 's9', 'data': {'level1': {'l2_val': 'v2', 'l2_none': None, 'l2_list': [1, {'l3_none': None, 'l3_val': 'v3'}, 3]}}}
+            ib_s9 = ibgib_s9['ib']
+            data_s9 = ibgib_s9['data']
+
+            # `l2_none` removed by to_normalized_for_hashing.
+            # `l3_none` within list's dict is preserved by to_normalized_for_hashing's shallow list copy.
+            # json.dumps with sort_keys=True will sort keys at all levels.
+            expected_normalized_data_s9 = {'level1': {'l2_list': [1, {'l3_none': None, 'l3_val': 'v3'}, 3], 'l2_val': 'v2'}}
+            actual_normalized_data_s9 = to_normalized_for_hashing(data_s9)
+            self.assertEqual(actual_normalized_data_s9, expected_normalized_data_s9)
+            
+            # json_string: {"level1":{"l2_list":[1,{"l3_none":null,"l3_val":"v3"},3],"l2_val":"v2"}}
+            # Note: keys in "l3_..." dict are sorted by json.dumps.
+            expected_data_hash_s9 = hash_to_hex_copy(json.dumps(actual_normalized_data_s9, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s9, "F8C3EF9BFBB9D927B55B3BA1FAAECAD1B35FA9B912AEAF9B75A807DA814CB975")
+
+            ib_hash_s9 = hash_to_hex_copy(ib_s9)
+            # Updated from test log
+            self.assertEqual(ib_hash_s9, "E72D310DBB213F4C2E34DA28935B38905332EE3628A04DF2DD13859FD769C6C5")
+
+            # For s9: has_data is True, has_rel8ns is False (rel8ns_hash is "").
+            expected_gib_s9 = hash_to_hex_copy(ib_hash_s9 + "" + expected_data_hash_s9)
+            # Updated based on new ib_hash_s9 and expected_data_hash_s9, value from FAIL log:
+            self.assertEqual(expected_gib_s9, "DB2F3306E2E91F22B0C7B10787760D0FE25BA79B7E3DFFE38164381EA06BE6A6")
+            
+            self.assertEqual(sha256v1(ibgib_s9), expected_gib_s9)
+
+        # Scenario 10a: `ibgib` with `data` but no `rel8ns` key.
+        with self.subTest(scenario="10a_data_no_rel8ns_key"):
+            ibgib_s10a = {'ib': 's10a', 'data': {'k': 'v'}}
+            ib_s10a = ibgib_s10a['ib']
+            data_s10a = ibgib_s10a['data']
+
+            expected_normalized_data_s10a = {'k': 'v'}
+            actual_normalized_data_s10a = to_normalized_for_hashing(data_s10a)
+            self.assertEqual(actual_normalized_data_s10a, expected_normalized_data_s10a)
+            expected_data_hash_s10a = hash_to_hex_copy(json.dumps(actual_normalized_data_s10a, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_data_hash_s10a, "666C1AA02E8068C6D5CC1D3295009432C16790BEC28EC8CE119D0D1A18D61319")
+
+            ib_hash_s10a = hash_to_hex_copy(ib_s10a)
+            # Updated from test log
+            self.assertEqual(ib_hash_s10a, "7674836E2F8926A8F0BE7998ABB44BACBC041BC51AF761F85E09A1349C60046C")
+
+            # For s10a: has_data is True, rel8ns key missing (rel8ns_hash is "", has_rel8ns False).
+            expected_gib_s10a = hash_to_hex_copy(ib_hash_s10a + "" + expected_data_hash_s10a)
+            # Updated based on new ib_hash_s10a and expected_data_hash_s10a, value from FAIL log:
+            self.assertEqual(expected_gib_s10a, "81C655EDEC7294CC0900430ED8EE0125EFF15C2F86EAF047C0E8FEFE0D4569E8")
+            
+            self.assertEqual(sha256v1(ibgib_s10a), expected_gib_s10a)
+
+        # Scenario 10b: `ibgib` with `rel8ns` but no `data` key.
+        with self.subTest(scenario="10b_rel8ns_no_data_key"):
+            ibgib_s10b = {'ib': 's10b', 'rel8ns': {'r': ['a']}}
+            ib_s10b = ibgib_s10b['ib']
+            rel8ns_s10b = ibgib_s10b['rel8ns']
+
+            expected_normalized_rel8ns_s10b = {'r': ['a']}
+            actual_normalized_rel8ns_s10b = to_normalized_for_hashing(rel8ns_s10b)
+            self.assertEqual(actual_normalized_rel8ns_s10b, expected_normalized_rel8ns_s10b)
+            expected_rel8ns_hash_s10b = hash_to_hex_copy(json.dumps(actual_normalized_rel8ns_s10b, sort_keys=True, separators=(',', ':')))
+            # Updated from test output:
+            self.assertEqual(expected_rel8ns_hash_s10b, "8A47C0659C530ACE4A79B55DE042782ABDFCC89848CDDB71260132B1FFE554AF")
+
+            ib_hash_s10b = hash_to_hex_copy(ib_s10b)
+            # Updated from test log
+            self.assertEqual(ib_hash_s10b, "BF2FDA41B9B401E5F86577387D6C97FCA6AB3F7A4222735C42390B587AC8517D")
+
+            # For s10b: data key missing (data_hash is "", has_data False), has_rel8ns is True.
+            expected_gib_s10b = hash_to_hex_copy(ib_hash_s10b + expected_rel8ns_hash_s10b + "")
+            # Updated based on new ib_hash_s10b and expected_rel8ns_hash_s10b, value from FAIL log:
+            self.assertEqual(expected_gib_s10b, "F35416C53D3683B60C2EE46DD1542A2A1D957F70D991D8DDEDC8C03715ED0DEA")
+            
+            self.assertEqual(sha256v1(ibgib_s10b), expected_gib_s10b)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…12 distinct test cases) to both the Python and TypeScript implementations of sha256v1 hashing for ibgib objects.

The new tests focus on:
- Handling of None/null/undefined and empty string values in `data` and `rel8ns`.
- Normalization of nested objects and objects within lists.
- Behavior with empty lists as `data`.
- Key sorting in `data` and `rel8ns`.
- Special characters in keys and string values.
- Primitive types (boolean, number) as `data`.
- `rel8ns` with mixed empty and non-empty relation lists.
- Deeply nested structures.
- ibgibs with `data` but no `rel8ns` key, and vice-versa.

The Python tests in `tests/py_gib/V1/test_sha256v1.py` were implemented first, and their resulting hash values (intermediate and final) were used as the ground truth for the TypeScript tests.

The TypeScript tests were added to `typescript-source/@ibgib/ts-gib/src/V1/sha256v1.respec.mts`, mirroring the Python test structure and assertions to ensure alignment in hashing behavior across both implementations for these identified edge cases.